### PR TITLE
#24: add "new feature or enhancement" as buildo issue (closes #24)

### DIFF
--- a/src/plugin/addNewBuildoIssueButton.js
+++ b/src/plugin/addNewBuildoIssueButton.js
@@ -84,6 +84,13 @@ export default function addNewBuildoIssueButton({ oldInterface }) {
 
   newBuildoIssueButton.on('click', () => newIssueOptions.toggle());
 
+  $(document.body).on('keydown.goToFeature', ({ keyCode, shiftKey }) => {
+    if (keyCode === 67 && !shiftKey) {
+      bindIssueTemplates(issueTypes[2])();
+      $(document.body).off('keydown.goToFeature');
+    }
+  })
+
   issueTypes.forEach( issue => $(`.${issue.className}`).on('click', bindIssueTemplates(issue)));
 
 }

--- a/src/plugin/addNewBuildoIssueButton.js
+++ b/src/plugin/addNewBuildoIssueButton.js
@@ -37,8 +37,8 @@ export default function addNewBuildoIssueButton({ oldInterface }) {
     className: 'buildo-new-feature-button',
     templateName: 'feature',
     titleTemplate: {
-      title: '[_topic_] _title',
-      selection: '_topic_'
+      title: '[{topic}] {title}',
+      selection: '{topic}'
     },
     labels: []
   }];

--- a/src/plugin/addNewBuildoIssueButton.js
+++ b/src/plugin/addNewBuildoIssueButton.js
@@ -31,6 +31,16 @@ export default function addNewBuildoIssueButton({ oldInterface }) {
     className: 'buildo-new-defect-button',
     templateName: 'defect',
     labels: ['defect']
+  }, {
+    title: 'New feature',
+    icon: 'paintcan',
+    className: 'buildo-new-feature-button',
+    templateName: 'feature',
+    titleTemplate: {
+      title: '[_topic_] _title',
+      selection: '_topic_'
+    },
+    labels: []
   }];
 
   const options = issueTypes.reduce((opts, { className, icon, title }) => `
@@ -65,11 +75,11 @@ export default function addNewBuildoIssueButton({ oldInterface }) {
 
   newBuildoIssueButton.on('click', () => newIssueOptions.toggle());
 
-  issueTypes.forEach(({ className, templateName, labels }) => {
+  issueTypes.forEach(({ className, templateName, labels, titleTemplate }) => {
     $(`.${className}`).on('click', () => {
       chrome.runtime.onMessage.addListener(function listener (message) {
         if (message.onNewIssuePage) {
-          prefillIssueWithTemplate({ templateName, labels });
+          prefillIssueWithTemplate({ templateName, labels, titleTemplate });
           chrome.runtime.onMessage.removeListener(listener);
         }
       });

--- a/src/plugin/addNewBuildoIssueButton.js
+++ b/src/plugin/addNewBuildoIssueButton.js
@@ -17,6 +17,15 @@ export default function addNewBuildoIssueButton({ oldInterface }) {
     </button>
   `);
 
+  const bindIssueTemplates = ({ templateName, labels, titleTemplate }) => () => {
+    chrome.runtime.onMessage.addListener(function listener (message) {
+      if (message.onNewIssuePage) {
+        prefillIssueWithTemplate({ templateName, labels, titleTemplate });
+        chrome.runtime.onMessage.removeListener(listener);
+      }
+    });
+  };
+
   const optionsStyle = 'top: 34px; right: 0px';
 
   const issueTypes = [{
@@ -75,15 +84,6 @@ export default function addNewBuildoIssueButton({ oldInterface }) {
 
   newBuildoIssueButton.on('click', () => newIssueOptions.toggle());
 
-  issueTypes.forEach(({ className, templateName, labels, titleTemplate }) => {
-    $(`.${className}`).on('click', () => {
-      chrome.runtime.onMessage.addListener(function listener (message) {
-        if (message.onNewIssuePage) {
-          prefillIssueWithTemplate({ templateName, labels, titleTemplate });
-          chrome.runtime.onMessage.removeListener(listener);
-        }
-      });
-    });
-  });
+  issueTypes.forEach( issue => $(`.${issue.className}`).on('click', bindIssueTemplates(issue)));
 
 }

--- a/src/plugin/enableActivePlaceholders.js
+++ b/src/plugin/enableActivePlaceholders.js
@@ -30,21 +30,21 @@ $.fn.getCursorPosition = function() {
   return pos;
 };
 
-export default function enableActivePlaceholders(issueBody) {
-  issueBody.click(function() {
+export default function enableActivePlaceholders(...elements) {
+  elements.forEach(el => el.click(function() {
     if (window.getSelection().toString().length) {
       return;
     }
-    const position = issueBody.getCursorPosition();
-    const ib = issueBody.val();
+    const position = el.getCursorPosition();
+    const ib = el.val();
     const beforeCursor = ib.substr(0, position);
     const afterCursor = ib.substr(position);
-    const afterStartBracket = beforeCursor.match(/\[[^\]]*$/);
-    const beforeEndBracket = afterCursor.match(/^[^\[]*\]/);
+    const afterStartBracket = beforeCursor.match(/\{[^\}]*$/);
+    const beforeEndBracket = afterCursor.match(/^[^\{]*\}/);
     if (afterStartBracket && beforeEndBracket) {
       const selectFrom = position - afterStartBracket[0].length;
       const selectTo = position + beforeEndBracket[0].length;
-      issueBody.selectRange(selectFrom, selectTo);
+      el.selectRange(selectFrom, selectTo);
     }
-  });
+  }));
 }

--- a/src/plugin/prefillIssueWithTemplate.js
+++ b/src/plugin/prefillIssueWithTemplate.js
@@ -76,7 +76,7 @@ export default function prefillIssueWithTemplate({ templateName, titleTemplate =
 
     setLabels(labels);
     setMilestone(milestone)
-    enableActivePlaceholders(issueBody);
+    enableActivePlaceholders(issueBody, issueTitle);
     issueTitle.click();
     setTitle(titleTemplate);
 

--- a/src/plugin/prefillIssueWithTemplate.js
+++ b/src/plugin/prefillIssueWithTemplate.js
@@ -2,7 +2,17 @@ import $ from 'jquery';
 import enableActivePlaceholders from './enableActivePlaceholders';
 require('arrive');
 
-export default function prefillIssueWithTemplate({ templateName, templateVariables = {}, labels = [], milestone }) {
+const subStringRange = (string, subString) => {
+  const startIndex = string.search(subString);
+  if (startIndex === -1) {
+    return [0, 0];
+  }
+  const endIndex = startIndex + subString.length;
+  return [startIndex, endIndex];
+}
+
+
+export default function prefillIssueWithTemplate({ templateName, titleTemplate = {}, templateVariables = {}, labels = [], milestone }) {
 
   document.arrive('.composer', {
     fireOnAttributesModification: true,
@@ -46,6 +56,12 @@ export default function prefillIssueWithTemplate({ templateName, templateVariabl
       });
     }
 
+    const setTitle = ({ title = '', selection = '' }) => {
+      const issueTitleDOMElem = issueTitle[0];
+      issueTitle.val(title);
+      issueTitleDOMElem.setSelectionRange(...subStringRange(title, selection));
+    }
+
     issueBody.prop('placeholder', 'Loading issue template...');
 
     $.get(`${templatesPath}/${templateName}.md`, (contents, status) => {
@@ -62,6 +78,7 @@ export default function prefillIssueWithTemplate({ templateName, templateVariabl
     setMilestone(milestone)
     enableActivePlaceholders(issueBody);
     issueTitle.click();
+    setTitle(titleTemplate);
 
   });
 

--- a/templates/bug.md
+++ b/templates/bug.md
@@ -1,11 +1,11 @@
 ## description
-[describe the buggy behavior]
+{describe the buggy behavior}
 
 ## how to reproduce
-- [optional: describe steps to reproduce bug]
+- {optional: describe steps to reproduce bug}
 
 ## specs
-[optional: describe a possible fix for this bug, if not obvious]
+{optional: describe a possible fix for this bug, if not obvious}
 
 ## misc
-[optional: other useful info]
+{optional: other useful info}

--- a/templates/defect.md
+++ b/templates/defect.md
@@ -1,11 +1,11 @@
 ## description
-[describe the defective behavior]
+{describe the defective behavior}
 
 ## how to reproduce
-- [optional: describe steps to reproduce defect]
+- {optional: describe steps to reproduce defect}
 
 ## specs
-[optional: describe a possible fix for this defect, if not obvious]
+{optional: describe a possible fix for this defect, if not obvious}
 
 ## misc
-[optional: other useful info]
+{optional: other useful info}

--- a/templates/feature.md
+++ b/templates/feature.md
@@ -1,0 +1,8 @@
+## requirements
+[describe the new feature]
+
+## specs
+[optional: describe technical specs to implement this feature, if not obvious]
+
+## misc
+[optional: other useful info]

--- a/templates/feature.md
+++ b/templates/feature.md
@@ -1,8 +1,8 @@
 ## requirements
-[describe the new feature]
+{describe the new feature}
 
 ## specs
-[optional: describe technical specs to implement this feature, if not obvious]
+{optional: describe technical specs to implement this feature, if not obvious}
 
 ## misc
-[optional: other useful info]
+{optional: other useful info}

--- a/templates/sub-issue.md
+++ b/templates/sub-issue.md
@@ -1,7 +1,7 @@
 ← #$parentIssueNo
 
 ## Requirements
-[requirements]
+{requirements}
 
 ## Specs
-[specs]
+{specs}

--- a/templates/sub-issue.md
+++ b/templates/sub-issue.md
@@ -1,7 +1,7 @@
 ← #$parentIssueNo
 
-## Requirements
+## requirements
 {requirements}
 
-## Specs
+## specs
 {specs}


### PR DESCRIPTION
Issue #24

## Test Plan
- there should be a new button in dropdown list, called 'new feature'
- created a template with sections as specified in the requirements, it would be visible only after deploy
- new template does not add any label
- new template prepopulates the title with `[{topic}] {title}` and `{topic}` is preselected.
- Besides, anytime one clicks on a word between curly brackets, the word is selected.
- last feature is valid also for the description section, it was already there but now placeholders are featured by curly brackets instead square ones. This choice was to preserve in the actual text the square brackets around [`topic`] and because curly brackets are more commons to feature placeholders

>  remap the c shortcut to this actions, overriding the default create issue

I had trouble to add this feature, maybe I need some help @FrancescoCioria 